### PR TITLE
fixed IE11 incompatibility with lodash library find functionality

### DIFF
--- a/src/common/routeConfig.js
+++ b/src/common/routeConfig.js
@@ -3,6 +3,7 @@ import { PageNotFound } from '../features/common';
 import homeRoute from '../features/home/route';
 import commonRoute from '../features/common/route';
 import examplesRoute from '../features/examples/route';
+import _ from 'lodash';
 
 // NOTE: DO NOT CHANGE the 'childRoutes' name and the declaration pattern.
 // This is used for Rekit cmds to register routes config for new features, and remove config when remove features, etc.
@@ -28,7 +29,7 @@ function handleIndexRoute(route) {
     return;
   }
 
-  const indexRoute = route.childRoutes.find(child => child.isIndex);
+  const indexRoute = _.find(route.childRoutes, (child => child.isIndex));
   if (indexRoute) {
     const first = { ...indexRoute };
     first.path = '';


### PR DESCRIPTION
IE11 has no implementation for the find-function. A clean workaround would be the usage of the find function from the lodash library.    